### PR TITLE
Fixed issues with INSTALL Markdown on GitHub

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,6 +87,7 @@ Build LLVM and Clang
 
   It's a good idea to build LLVM in parallel, so use `-j` if you can
 
+
 		cd .. # Back to llvm directory
 		./configure [--enable-optimized] && make [-j4]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,17 +79,17 @@ Build LLVM and Clang
 - First check out the projects
 
 
-	svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
-	cd llvm/tools
-	svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
+		svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
+		cd llvm/tools
+		svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
 
 - Build both projects but don't install them
 
-  It's a good idea to build LLVM in parallel, so use `-j` if you can
+It's a good idea to build LLVM in parallel, so use `-j` if you can
 
 
-	cd .. # Back to llvm directory
-	./configure [--enable-optimized] && make [-j4]
+		cd .. # Back to llvm directory
+		./configure [--enable-optimized] && make [-j4]
 
   Both LLVM and Clang have been built in debug mode.
 
@@ -103,8 +103,8 @@ Build LLVM and Clang
 - Finally expose LLVM and Clang:
 
 
-	export PATH=$PATH:$PWD/Debug/bin: # llvm/Debug/bin contains the clang binary
-	export CC=clang # Make Clang the C/ObjC compiler rather than GCC
+		export PATH=$PATH:$PWD/Debug/bin: # llvm/Debug/bin contains the clang binary
+		export CC=clang # Make Clang the C/ObjC compiler rather than GCC
 
   A good choice is put the two lines above in `~/.bashrc` or similar and open a new shell.
   This way you won't have to export these variable every time you want to compile GNUstep or Étoilé stuff.
@@ -112,7 +112,7 @@ Build LLVM and Clang
 - Check Clang is ready:
 
 
-    clang -v
+		clang -v
 
 Build and Install GNUstep
 -------------------------

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,16 +79,16 @@ Build LLVM and Clang
 - First check out the projects
 
 
-  	svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
-  	cd llvm/tools
-  	svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
+		svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
+		cd llvm/tools
+		svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
 
 - Build both projects but don't install them
 
   It's a good idea to build LLVM in parallel, so use `-j` if you can
 
-  	cd .. # Back to llvm directory
-  	./configure [--enable-optimized] && make [-j4]
+		cd .. # Back to llvm directory
+		./configure [--enable-optimized] && make [-j4]
 
   Both LLVM and Clang have been built in debug mode.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,17 +122,17 @@ To build GNUstep with Clang:
 - Check out GNUstep core modules and libobjc2:
 
 
-	svn co http://svn.gna.org/svn/gnustep/modules/core
-	svn co http://svn.gna.org/svn/gnustep/libs/libobjc2/trunk libobjc2
+		svn co http://svn.gna.org/svn/gnustep/modules/core
+		svn co http://svn.gna.org/svn/gnustep/libs/libobjc2/trunk libobjc2
 
 - Install GNUstep Make a first time:
 
 
-	cd core/make
-	./configure --enable-debug-by-default --with-layout=gnustep [--prefix=/]
-	make && sudo -E make install
-	. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
-	# Or . /System/Library/Makefiles/GNUstep.sh if --prefix=/ was passed
+		cd core/make
+		./configure --enable-debug-by-default --with-layout=gnustep [--prefix=/]
+		make && sudo -E make install
+		. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+		# Or . /System/Library/Makefiles/GNUstep.sh if --prefix=/ was passed
 
   A good choice is to put this last line above in `~/.bashrc` or similar. This way
   you won't have to source `GNUstep.sh` every time you want to compile GNUstep or
@@ -145,15 +145,15 @@ To build GNUstep with Clang:
   Install/strip ensures you can debug ObjC code without stepping inside runtime functions each time a message is sent.
 
 
-	cd ../../libobjc2
-	mkdir Build
-	cd Build
-	cmake -DCMAKE_CXX_COMPILER=clang++ -DTESTS=FALSE ..
-	make && sudo -E make install/strip
+		cd ../../libobjc2
+		mkdir Build
+		cd Build
+		cmake -DCMAKE_CXX_COMPILER=clang++ -DTESTS=FALSE ..
+		make && sudo -E make install/strip
 
   A special sudo invocation for `make install` will be required if sudo uses a secure `PATH` variable:
 
-	make && sudo sh -c "." $GNUSTEP_MAKEFILES/GNUstep.sh; make install/strip
+		make && sudo sh -c "." $GNUSTEP_MAKEFILES/GNUstep.sh; make install/strip
 
   You can also edit `/etc/sudoers` using visudo and comment out the line `Defaults secure_path=XXX`. Which means `sudo -E` now inherits the `PATH` variable as customized by `GNUstep.sh` and the gnustep-config tool can be found (by the libobjc2 GNUmakefile). If the secure path support has been disabled, `sudo -E make install` will work as is to install GNUstep and Etoile, in the next instructions.
 
@@ -162,17 +162,17 @@ To build GNUstep with Clang:
 - Install GNUstep Make a second time so it can detect the new ObjC runtime just installed:
 
 
-	cd ../../../core/make
-	./configure --enable-debug-by-default --enable-objc-nonfragile-abi --with-layout=gnustep [--prefix=/]
-	make && sudo -E make install
+		cd ../../../core/make
+		./configure --enable-debug-by-default --enable-objc-nonfragile-abi --with-layout=gnustep [--prefix=/]
+		make && sudo -E make install
 
 - Build and Install GNUstep Base, Gui and Back:
 
 
-	cd ../../core/base
-	# For Linux e.g. Ubuntu, --with-ffi-include is usually required
-	./configure --disable-mixedabi [--with-ffi-include=/usr/include/`gcc -dumpmachine`]
-    make && sudo -E make install
+		cd ../../core/base
+		# For Linux e.g. Ubuntu, --with-ffi-include is usually required
+		./configure --disable-mixedabi [--with-ffi-include=/usr/include/`gcc -dumpmachine`]
+		make && sudo -E make install
 
 	cd ../../core/gui
 	./configure && make && sudo -E make install
@@ -197,21 +197,21 @@ this topic.
 - Build and Install libdispatch (requires CMake 2.8 or higher)
 
 
-	cd ../..
-	git clone https://github.com/etoile/libdispatch-objc2
-	# For more detailed instructions, see libdispatch-lobjc2/INSTALL
-	mkdir libdispatch-objc2/Build
-	cd libdispatch-objc2/Build
-	cmake -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release ..
-	make && sudo -E make install
+		cd ../..
+		git clone https://github.com/etoile/libdispatch-objc2
+		# For more detailed instructions, see libdispatch-lobjc2/INSTALL
+		mkdir libdispatch-objc2/Build
+		cd libdispatch-objc2/Build
+		cmake -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release ..
+		make && sudo -E make install
 
 - Build and Install Etoile:
 
-Go to the Etoile directory that contains this INSTALL document
+  Go to the Etoile directory that contains this INSTALL document
 
 
-	make # Don't use -j flag
-	[sudo] [-E] make install
+		make # Don't use -j flag
+		[sudo] [-E] make install
 
   **Warning:** If *Smalltalk.h not found* is reported, then it is usually because the `-j`flag was passed to GNUstep Make. GNUstep Make sometimes doesn't track the dependencies correctly for compiling SmalltalkParser.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ Build LLVM and Clang
 
 - Build both projects but don't install them
 
-It's a good idea to build LLVM in parallel, so use `-j` if you can
+  It's a good idea to build LLVM in parallel, so use `-j` if you can
 
 
 		cd .. # Back to llvm directory

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,17 +79,17 @@ Build LLVM and Clang
 - First check out the projects
 
 
-    svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
-    cd llvm/tools
-    svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
+	svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
+	cd llvm/tools
+	svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
 
 - Build both projects but don't install them
 
   It's a good idea to build LLVM in parallel, so use `-j` if you can
 
 
-    cd .. # Back to llvm directory
-    ./configure [--enable-optimized] && make [-j4]
+	cd .. # Back to llvm directory
+	./configure [--enable-optimized] && make [-j4]
 
   Both LLVM and Clang have been built in debug mode.
 
@@ -103,8 +103,8 @@ Build LLVM and Clang
 - Finally expose LLVM and Clang:
 
 
-    export PATH=$PATH:$PWD/Debug/bin: # llvm/Debug/bin contains the clang binary
-    export CC=clang # Make Clang the C/ObjC compiler rather than GCC
+	export PATH=$PATH:$PWD/Debug/bin: # llvm/Debug/bin contains the clang binary
+	export CC=clang # Make Clang the C/ObjC compiler rather than GCC
 
   A good choice is put the two lines above in `~/.bashrc` or similar and open a new shell.
   This way you won't have to export these variable every time you want to compile GNUstep or Étoilé stuff.
@@ -122,17 +122,17 @@ To build GNUstep with Clang:
 - Check out GNUstep core modules and libobjc2:
 
 
-    svn co http://svn.gna.org/svn/gnustep/modules/core
-    svn co http://svn.gna.org/svn/gnustep/libs/libobjc2/trunk libobjc2
+	svn co http://svn.gna.org/svn/gnustep/modules/core
+	svn co http://svn.gna.org/svn/gnustep/libs/libobjc2/trunk libobjc2
 
 - Install GNUstep Make a first time:
 
 
-    cd core/make
-    ./configure --enable-debug-by-default --with-layout=gnustep [--prefix=/]
-    make && sudo -E make install
-    . /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
-    # Or . /System/Library/Makefiles/GNUstep.sh if --prefix=/ was passed
+	cd core/make
+	./configure --enable-debug-by-default --with-layout=gnustep [--prefix=/]
+	make && sudo -E make install
+	. /usr/GNUstep/System/Library/Makefiles/GNUstep.sh
+	# Or . /System/Library/Makefiles/GNUstep.sh if --prefix=/ was passed
 
   A good choice is to put this last line above in `~/.bashrc` or similar. This way
   you won't have to source `GNUstep.sh` every time you want to compile GNUstep or
@@ -145,15 +145,15 @@ To build GNUstep with Clang:
   Install/strip ensures you can debug ObjC code without stepping inside runtime functions each time a message is sent.
 
 
-    cd ../../libobjc2
-    mkdir Build
-    cd Build
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DTESTS=FALSE ..
-    make && sudo -E make install/strip
+	cd ../../libobjc2
+	mkdir Build
+	cd Build
+	cmake -DCMAKE_CXX_COMPILER=clang++ -DTESTS=FALSE ..
+	make && sudo -E make install/strip
 
   A special sudo invocation for `make install` will be required if sudo uses a secure `PATH` variable:
 
-    make && sudo sh -c "." $GNUSTEP_MAKEFILES/GNUstep.sh; make install/strip
+	make && sudo sh -c "." $GNUSTEP_MAKEFILES/GNUstep.sh; make install/strip
 
   You can also edit `/etc/sudoers` using visudo and comment out the line `Defaults secure_path=XXX`. Which means `sudo -E` now inherits the `PATH` variable as customized by `GNUstep.sh` and the gnustep-config tool can be found (by the libobjc2 GNUmakefile). If the secure path support has been disabled, `sudo -E make install` will work as is to install GNUstep and Etoile, in the next instructions.
 
@@ -162,23 +162,23 @@ To build GNUstep with Clang:
 - Install GNUstep Make a second time so it can detect the new ObjC runtime just installed:
 
 
-    cd ../../../core/make
-    ./configure --enable-debug-by-default --enable-objc-nonfragile-abi --with-layout=gnustep [--prefix=/]
-    make && sudo -E make install
+	cd ../../../core/make
+	./configure --enable-debug-by-default --enable-objc-nonfragile-abi --with-layout=gnustep [--prefix=/]
+	make && sudo -E make install
 
 - Build and Install GNUstep Base, Gui and Back:
 
 
-    cd ../../core/base
-    # For Linux e.g. Ubuntu, --with-ffi-include is usually required
-    ./configure --disable-mixedabi [--with-ffi-include=/usr/include/`gcc -dumpmachine`]
+	cd ../../core/base
+	# For Linux e.g. Ubuntu, --with-ffi-include is usually required
+	./configure --disable-mixedabi [--with-ffi-include=/usr/include/`gcc -dumpmachine`]
     make && sudo -E make install
 
-    cd ../../core/gui
-    ./configure && make && sudo -E make install
+	cd ../../core/gui
+	./configure && make && sudo -E make install
 
-    cd ../../core/back
-    ./configure && make && sudo -E make install
+	cd ../../core/back
+	./configure && make && sudo -E make install
 
   You can check you are really using Clang and not GCC with `make messages=yes` instead of `make` when building a GNUstep module.
   You can switch back to GCC for a given project with `make CC=gcc` (or alternatively `./configure CC=gcc`).
@@ -197,21 +197,21 @@ this topic.
 - Build and Install libdispatch (requires CMake 2.8 or higher)
 
 
-    cd ../..
-    git clone https://github.com/etoile/libdispatch-objc2
-    # For more detailed instructions, see libdispatch-lobjc2/INSTALL
-    mkdir libdispatch-objc2/Build
-    cd libdispatch-objc2/Build
-    cmake -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release ..
-    make && sudo -E make install
+	cd ../..
+	git clone https://github.com/etoile/libdispatch-objc2
+	# For more detailed instructions, see libdispatch-lobjc2/INSTALL
+	mkdir libdispatch-objc2/Build
+	cd libdispatch-objc2/Build
+	cmake -DCMAKE_C_COMPILER=clang -DCMAKE_BUILD_TYPE=Release ..
+	make && sudo -E make install
 
 - Build and Install Etoile:
 
-	Go to the Etoile directory that contains this INSTALL document
+Go to the Etoile directory that contains this INSTALL document
 
 
-    make # Don't use -j flag
-    [sudo] [-E] make install
+	make # Don't use -j flag
+	[sudo] [-E] make install
 
   **Warning:** If *Smalltalk.h not found* is reported, then it is usually because the `-j`flag was passed to GNUstep Make. GNUstep Make sometimes doesn't track the dependencies correctly for compiling SmalltalkParser.
 
@@ -221,7 +221,7 @@ Uninstall Étoilé
 
 Go to the Etoile directory that contains this INSTALL document
 
-    [sudo] [-E] make uninstall
+	[sudo] [-E] make uninstall
 
 Custom Build and Install
 ------------------------
@@ -230,15 +230,15 @@ In order to build and install the whole project (with the exception of
 developers tools like UnitKit), you can just type in the root directory (named
 Etoile):
 
-    make
-    [sudo] [-E] make install
+	make
+	[sudo] [-E] make install
 
 You can choose to build only custom set of modules. Add a 'modules.make' file in
 the root directory named 'Etoile' that contains Frameworks, Services and so on.
 In this file, to turn on the module CoreObject and off the module UnitKit, write:
 
-    export coreobject = yes
-    export unitkit = no
+	export coreobject = yes
+	export unitkit = no
 
 Be careful to have no trailing spaces after 'yes' or 'no'.
 Take also note by declaring these variables, you only determine whether these
@@ -261,22 +261,22 @@ Generate Documentation
 
 To build both the code and the documentation at the same time in any directory, type:
 
-    make documentation=yes
+	make documentation=yes
 
 In addition, you can also generate the documentation without building the code per module. Move to a module directory (e.g. cd Languages/LanguageKit) and do:
 
-    make doc
+	make doc
 
 Every time you generate some documentation, a Documentation directory appears per module (e.g. Languages/LanguageKit/Documentation) and it gets consolidated in Developer/Documentation. You can browse the Developer/Documentation/index.html as a starting point.
 If you are in a module directory, you can browse its documentation with Documentation/index.html (e.g. Languages/LanguageKit/Documentation/index.html)
 
 To clean the generated documentation in the current module directory (will also clean the content copied in Developer/Documentation):
 
-    make clean-doc
+	make clean-doc
 
 Finally to remove all the generated documentation, you can use in any directory:
 
-    make distclean
+	make distclean
 
 which also discards the code previously built.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,17 +79,16 @@ Build LLVM and Clang
 - First check out the projects
 
 
-		svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
-		cd llvm/tools
-		svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
+  	svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
+  	cd llvm/tools
+  	svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
 
 - Build both projects but don't install them
 
   It's a good idea to build LLVM in parallel, so use `-j` if you can
 
-
-		cd .. # Back to llvm directory
-		./configure [--enable-optimized] && make [-j4]
+  	cd .. # Back to llvm directory
+  	./configure [--enable-optimized] && make [-j4]
 
   Both LLVM and Clang have been built in debug mode.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,11 +174,11 @@ To build GNUstep with Clang:
 		./configure --disable-mixedabi [--with-ffi-include=/usr/include/`gcc -dumpmachine`]
 		make && sudo -E make install
 
-	cd ../../core/gui
-	./configure && make && sudo -E make install
+		cd ../../core/gui
+		./configure && make && sudo -E make install
 
-	cd ../../core/back
-	./configure && make && sudo -E make install
+		cd ../../core/back
+		./configure && make && sudo -E make install
 
   You can check you are really using Clang and not GCC with `make messages=yes` instead of `make` when building a GNUstep module.
   You can switch back to GCC for a given project with `make CC=gcc` (or alternatively `./configure CC=gcc`).


### PR DESCRIPTION
Unfortunately GitHub flavoured Markdown does not appear to respect code blocks that use spaces rather than tabs. This PR replaces the spaces with tabs and makes some other minor tweaks by adding an extra tab when the code block is nested in an item in an unordered list.
